### PR TITLE
Update README.md with more instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Scripts to flash firmware and ROM on windows/mac/linux, including latest platfor
 2. Copy it to this folder and rename it to aospa.zip
 3. Download the latest Android 14 firmware for your variant from https://xiaomifirmwareupdater.com/firmware/marble/ (see note below for RN12T)
 4. Copy it to this folder and rename it to firmware.zip
-5. Run the appropriate scripts in the following order:
-   1. install_google_usb_driver (Windows users only; requires admin)
-   2. flash_firmware
-   3. flash_aospa
+5. Run install_google_usb_driver (Windows users only; requires admin)
+6. Reboot to bootloader (`adb reboot bootloader`)
+7. Run flash_firmware
+8. Run flash_aospa
 
 ### Notes
 - `.cmd` scripts are for windows, can be run by right click -> run as administrator.  


### PR DESCRIPTION
Currently in README.md the user was not instructed explicitly to first enter fastboot mode. Simply running the flash_firmware script will wait forever for the device. I think it's probably better to add one step telling the user to reboot to bootloader before running the flash_firmware and flash_aospa scripts.